### PR TITLE
[t145928] Company CCS Style

### DIFF
--- a/web_company_color/models/res_company.py
+++ b/web_company_color/models/res_company.py
@@ -15,6 +15,8 @@ class ResCompany(models.Model):
     _inherit = "res.company"
 
     SCSS_TEMPLATE = """
+        @import "functions";
+        @import "variables";
         .o_main_navbar {
           background: %(color_navbar_bg)s !important;
           background-color: %(color_navbar_bg)s !important;


### PR DESCRIPTION
The client want to have by company a different color defined for the header of the menu bar. 

This app exists but seams not to work:

https://github.com/OCA/web/tree/16.0/web_company_color



Please debug and check why. 

<!-- BT_AUTOLINKS_START --> 
<div> Links to Odoo: </div> <ul>
<li><a target="_blank" href="https://braintec.com/web#view_type=form&model=project.task&id=145928">[t145928] Company CCS Style</a></li>
</ul>
<div>Affected Modules:</div>
<table><thead><tr><th>Module</th><th>Ext</th></tr></thead>
<tr><td>web_company_color</td><td>.py</td></tr>
</tbody></table>
<!-- BT_AUTOLINKS_END -->